### PR TITLE
1.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.10.2" %}
-{% set build_number = "5" %}
+{% set version = "1.12.1" %}
+{% set build_number = "0" %}
 
 package:
   name: ninja-suite
@@ -8,7 +8,7 @@ package:
 source:
   fn: v{{ version }}.tar.gz
   url: https://github.com/ninja-build/ninja/archive/v{{ version }}.tar.gz
-  sha256: ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed
+  sha256: 821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a
 
 build:
   number: {{ build_number }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ outputs:
         - {{ compiler("cxx") }}
         - cmake
         - make  # [not win]
+        - gtest
     test:
       commands:
         - ninja --version


### PR DESCRIPTION
ninja 1.12.1

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-6100
- https://github.com/ninja-build/ninja/releases
- https://github.com/ninja-build/ninja/tree/v1.12.1

### Explanation of changes:

- This seems to help with sporadic meson-python build failures. 
